### PR TITLE
Have `_validate_var_names` support `csr_matrix`

### DIFF
--- a/scarches/models/base/_utils.py
+++ b/scarches/models/base/_utils.py
@@ -34,8 +34,8 @@ def _validate_var_names(adata, source_var_names):
         print("The missing information will be filled with zeroes.")
        
         filling_X = np.zeros((len(adata), len(ref_genes_not_in_query)))
-        if isinstance(adata.X, csr_matrix): # support sparse matrix
-            filling_X = csr_matrix(filling_X)
+        if isinstance(adata.X, csr_matrix): 
+            filling_X = csr_matrix(filling_X) # support csr sparse matrix
             new_target_X = hstack((adata.X, filling_X))
         else:
             new_target_X = np.concatenate((adata.X, filling_X), axis=1)

--- a/scarches/models/base/_utils.py
+++ b/scarches/models/base/_utils.py
@@ -34,7 +34,7 @@ def _validate_var_names(adata, source_var_names):
         print("The missing information will be filled with zeroes.")
        
         filling_X = np.zeros((len(adata), len(ref_genes_not_in_query)))
-        if isinstance(adata, csr_matrix): # support sparse matrix
+        if isinstance(adata.X, csr_matrix): # support sparse matrix
             filling_X = csr_matrix(filling_X)
             new_target_X = hstack((adata.X, filling_X))
         else:

--- a/scarches/models/base/_utils.py
+++ b/scarches/models/base/_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import logging
 from anndata import AnnData
+from scipy.sparse import csr_matrix, hstack
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +32,13 @@ def _validate_var_names(adata, source_var_names):
               len(ref_genes_not_in_query),
               " genes which were contained in the reference dataset.")
         print("The missing information will be filled with zeroes.")
-
+       
         filling_X = np.zeros((len(adata), len(ref_genes_not_in_query)))
-        new_target_X = np.concatenate((adata.X, filling_X), axis=1)
+        if isinstance(rmb.adata_query.X, csr_matrix): # support sparse matrix
+            filling_X = csr_matrix(filling_X)
+            new_target_X = hstack((rmb.adata_query.X, filling_X))
+        else:
+            new_target_X = np.concatenate((adata.X, filling_X), axis=1)
         new_target_vars = adata.var_names.tolist() + ref_genes_not_in_query
         new_adata = AnnData(new_target_X, dtype="float32")
         new_adata.var_names = new_target_vars

--- a/scarches/models/base/_utils.py
+++ b/scarches/models/base/_utils.py
@@ -34,9 +34,9 @@ def _validate_var_names(adata, source_var_names):
         print("The missing information will be filled with zeroes.")
        
         filling_X = np.zeros((len(adata), len(ref_genes_not_in_query)))
-        if isinstance(rmb.adata_query.X, csr_matrix): # support sparse matrix
+        if isinstance(adata, csr_matrix): # support sparse matrix
             filling_X = csr_matrix(filling_X)
-            new_target_X = hstack((rmb.adata_query.X, filling_X))
+            new_target_X = hstack((adata.X, filling_X))
         else:
             new_target_X = np.concatenate((adata.X, filling_X), axis=1)
         new_target_vars = adata.var_names.tolist() + ref_genes_not_in_query


### PR DESCRIPTION
When reference and query dataset have different `var_names`, and `adata.X` is a `scipy.sparse.csr_matrix`, then `_validate_var_names` fails with a `ValueError: zero-dimensional arrays cannot be concatenated`.
It might be nice to support sparse matrices as input, since it's often the default in AnnData.