### PR TITLE
Fix issue #224 / Improve handling of unlabled cells

### DIFF
--- a/scarches/models/scpoli/scpoli.py
+++ b/scarches/models/scpoli/scpoli.py
@@ -235,6 +235,9 @@ class scpoli(nn.Module):
         self.cell_type_encoder = {
             k: v for k, v in zip(self.cell_types, range(len(self.cell_types)))
         }
+        if self.unknown_ct_names is not None:
+            for unknown_ct in self.unknown_ct_names:
+                self.cell_type_encoder[unknown_ct] = -1
 
         # Add new celltype index to hierarchy index list of prototypes
         classes_list = torch.cat(

--- a/scarches/models/scpoli/scpoli_model.py
+++ b/scarches/models/scpoli/scpoli_model.py
@@ -122,7 +122,7 @@ class scPoli(BaseMixin):
         self.unknown_ct_names_ = unknown_ct_names
 
         if labeled_indices is None:
-            self.labeled_indices_ = range(len(adata))
+            self.labeled_indices_ = np.argwhere(adata.obs[self.cell_type_keys_].isin(self.unknown_ct_names_).to_numpy().astype(int).min(axis=1) == 0).T[0]
         else:
             self.labeled_indices_ = labeled_indices
 
@@ -179,7 +179,6 @@ class scPoli(BaseMixin):
             for unknown_ct in self.unknown_ct_names_:
                 if unknown_ct in self.cell_types_:
                     del self.cell_types_[unknown_ct]
-
 
         # store model parameters
         if hidden_layer_sizes is None:


### PR DESCRIPTION
This PR solves #224.
In scPoli, labeled_indices should be passed if all labels are not available. In this PR we infer it from unknown_ct_names parameter. In addition, a minor bug is fixed.