### PR TITLE
Remove deprecated anndata.read imports and replace with anndat.read_h5ad

### DIFF
--- a/scarches/models/base/_base.py
+++ b/scarches/models/base/_base.py
@@ -7,7 +7,8 @@ from typing import Optional, Union
 import numpy as np
 import torch
 from torch.distributions import Normal
-from anndata import AnnData, read
+import anndata as ad
+from anndata import AnnData
 from scipy.sparse import issparse
 
 from ._utils import UnpicklerCpu, _validate_var_names
@@ -173,7 +174,7 @@ class BaseMixin:
         load_adata = adata is None
 
         if os.path.exists(adata_path) and load_adata:
-            adata = read(adata_path)
+            adata = ad.read_h5ad(adata_path)
         elif not os.path.exists(adata_path) and load_adata:
             raise ValueError("Save path contains no saved anndata and no adata was passed.")
 

--- a/scarches/models/expimap/expimap_model.py
+++ b/scarches/models/expimap/expimap_model.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import pandas as pd
 
-from anndata import AnnData, read
+from anndata import AnnData
 from copy import deepcopy
 from typing import Optional, Union
 

--- a/scarches/models/trvae/trvae_model.py
+++ b/scarches/models/trvae/trvae_model.py
@@ -4,7 +4,7 @@ import torch
 import pickle
 import numpy as np
 
-from anndata import AnnData, read
+from anndata import AnnData
 from copy import deepcopy
 from typing import Optional, Union
 


### PR DESCRIPTION
Fixing: https://github.com/theislab/scarches/issues/276

When using scarches with a newer version of anndata 

`ImportError: cannot import name 'read' from 'anndata'`

Two of the imports were unused anyways.
