### PR TITLE
Update deprecated scipy attributes

### DIFF
--- a/scarches/dataset/scpoli/_utils.py
+++ b/scarches/dataset/scpoli/_utils.py
@@ -15,7 +15,7 @@ def remove_sparsity(adata):
             Annotated dataset.
     """
     if sparse.issparse(adata.X):
-        new_adata = sc.AnnData(X=adata.X.A, obs=adata.obs.copy(deep=True), var=adata.var.copy(deep=True))
+        new_adata = sc.AnnData(X=adata.X.toarray(), obs=adata.obs.copy(deep=True), var=adata.var.copy(deep=True))
         return new_adata
 
     return adata

--- a/scarches/dataset/trvae/data_handling.py
+++ b/scarches/dataset/trvae/data_handling.py
@@ -15,7 +15,7 @@ def remove_sparsity(adata):
             Annotated dataset.
     """
     if sparse.issparse(adata.X):
-        new_adata = sc.AnnData(X=adata.X.A, obs=adata.obs.copy(deep=True), var=adata.var.copy(deep=True))
+        new_adata = sc.AnnData(X=adata.X.toarray(), obs=adata.obs.copy(deep=True), var=adata.var.copy(deep=True))
         return new_adata
 
     return adata

--- a/scarches/models/base/_base.py
+++ b/scarches/models/base/_base.py
@@ -7,7 +7,8 @@ from typing import Optional, Union
 import numpy as np
 import torch
 from torch.distributions import Normal
-from anndata import AnnData, read
+import anndata as ad
+from anndata import AnnData
 from scipy.sparse import issparse
 
 from ._utils import UnpicklerCpu, _validate_var_names
@@ -173,7 +174,7 @@ class BaseMixin:
         load_adata = adata is None
 
         if os.path.exists(adata_path) and load_adata:
-            adata = read(adata_path)
+            adata = ad.read_h5ad(adata_path)
         elif not os.path.exists(adata_path) and load_adata:
             raise ValueError("Save path contains no saved anndata and no adata was passed.")
 

--- a/scarches/models/expimap/expimap_model.py
+++ b/scarches/models/expimap/expimap_model.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import pandas as pd
 
-from anndata import AnnData, read
+from anndata import AnnData
 from copy import deepcopy
 from typing import Optional, Union
 

--- a/scarches/models/scgen/_utils.py
+++ b/scarches/models/scgen/_utils.py
@@ -56,7 +56,7 @@ def balancer(adata, cell_type_key="cell_type", condition_key="condition"):
         temp = adata.copy()[adata.obs[cell_type_key] == cls]
         index = np.random.choice(range(len(temp)), max_number)
         if sparse.issparse(temp.X):
-            temp_x = temp.X.A[index]
+            temp_x = temp.X.toarray()[index]
         else:
             temp_x = temp.X[index]
         all_data_x.append(temp_x)

--- a/scarches/models/scgen/vaearith.py
+++ b/scarches/models/scgen/vaearith.py
@@ -213,15 +213,15 @@ class vaeArith(nn.Module):
         cd_ind = np.random.choice(range(ctrl_x.shape[0]), size=eq, replace=False)
         stim_ind = np.random.choice(range(stim_x.shape[0]), size=eq, replace=False)
         if sparse.issparse(ctrl_x.X) and sparse.issparse(stim_x.X):
-            latent_ctrl = self._avg_vector(torch.tensor(ctrl_x.X.A[cd_ind, :], device=device))
-            latent_sim = self._avg_vector(torch.tensor(stim_x.X.A[stim_ind, :], device=device))
+            latent_ctrl = self._avg_vector(torch.tensor(ctrl_x.X.toarray()[cd_ind, :], device=device))
+            latent_sim = self._avg_vector(torch.tensor(stim_x.X.toarray()[stim_ind, :], device=device))
         else:
             latent_ctrl = self._avg_vector(torch.tensor(ctrl_x.X[cd_ind, :], device=device))
             latent_sim = self._avg_vector(torch.tensor(stim_x.X[stim_ind, :], device=device))
 
         delta = latent_sim - latent_ctrl
         if sparse.issparse(ctrl_pred.X):
-            latent_cd = self.get_latent(torch.tensor(ctrl_pred.X.A, device=device))
+            latent_cd = self.get_latent(torch.tensor(ctrl_pred.X.toarray(), device=device))
         else:
             latent_cd = self.get_latent(torch.tensor(ctrl_pred.X, device=device))
 
@@ -252,7 +252,7 @@ class vaeArith(nn.Module):
         """
         device = next(self.parameters()).device # get device of model.parameters
         if sparse.issparse(adata.X):
-            latent_all = (self.get_latent(torch.tensor(adata.X.A, device=device))).cpu().detach().numpy()
+            latent_all = (self.get_latent(torch.tensor(adata.X.toarray(), device=device))).cpu().detach().numpy()
         else:
             latent_all = (self.get_latent(torch.tensor(adata.X, device=device))).cpu().detach().numpy()
 

--- a/scarches/models/scpoli/scpoli_model.py
+++ b/scarches/models/scpoli/scpoli_model.py
@@ -456,7 +456,7 @@ class scPoli(BaseMixin):
             x = adata
 
         if sparse.issparse(x):
-            x = x.A
+            x = x.toarray()
         x = torch.tensor(x, device=device)
 
         results = dict()
@@ -569,7 +569,7 @@ class scPoli(BaseMixin):
             c = torch.tensor(label_tensor, device=device).T
 
         if sparse.issparse(x):
-            x = x.A
+            x = x.toarray()
         x = torch.tensor(x, device=device)
         latents = []
         indices = torch.arange(x.size(0), device=device)

--- a/scarches/models/trvae/trvae_model.py
+++ b/scarches/models/trvae/trvae_model.py
@@ -4,7 +4,7 @@ import torch
 import pickle
 import numpy as np
 
-from anndata import AnnData, read
+from anndata import AnnData
 from copy import deepcopy
 from typing import Optional, Union
 

--- a/scarches/trainers/scgen/_utils.py
+++ b/scarches/trainers/scgen/_utils.py
@@ -111,7 +111,7 @@ def balancer(adata, cell_type_key="cell_type", condition_key="condition"):
         temp = adata.copy()[adata.obs[cell_type_key] == cls]
         index = np.random.choice(range(len(temp)), max_number)
         if sparse.issparse(temp.X):
-            temp_x = temp.X.A[index]
+            temp_x = temp.X.toarray()[index]
         else:
             temp_x = temp.X[index]
         all_data_x.append(temp_x)

--- a/scarches/trainers/scgen/trainer.py
+++ b/scarches/trainers/scgen/trainer.py
@@ -119,7 +119,7 @@ class vaeArithTrainer:
             for lower in range(0, train_adata.shape[0], self.batch_size):
                 upper = min(lower + self.batch_size, train_adata.shape[0])
                 if sparse.issparse(train_adata.X):
-                    x_mb = torch.from_numpy(train_adata[lower:upper, :].X.A)
+                    x_mb = torch.from_numpy(train_adata[lower:upper, :].X.toarray())
                 else:
                     x_mb = torch.from_numpy(train_adata[lower:upper, :].X)
                 if upper - lower > 1:
@@ -146,7 +146,7 @@ class vaeArithTrainer:
                 for lower in range(0, train_adata.shape[0], self.batch_size):
                     upper = min(lower + self.batch_size, train_adata.shape[0])
                     if sparse.issparse(train_adata.X):
-                        x_mb = torch.from_numpy(train_adata[lower:upper, :].X.A)
+                        x_mb = torch.from_numpy(train_adata[lower:upper, :].X.toarray())
                     else:
                         x_mb = torch.from_numpy(train_adata[lower:upper, :].X)
                     if upper - lower > 1:


### PR DESCRIPTION
scipy deprecated the csr_matrix.A attribute awhile ago and it was fully removed as of v1.14.0 (https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html). 

Here is a PR in another theislab project that does a similar fix https://github.com/theislab/cellrank/pull/1214/files

@Koncopd I'm not sure if I got all of them (I had this issue when trying to use scPoli with a more recent version of scipy).